### PR TITLE
Add create list button for blank page

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -17,7 +17,7 @@ export const App: FC = () => {
   return (
     <>
       <HeaderComponent list={list} setList={setList} />
-      <MainComponent list={list} loading={listLoading} />
+      <MainComponent list={list} loading={listLoading} setList={setList} />
     </>
   );
 };

--- a/src/ui/FlyoutMenu.tsx
+++ b/src/ui/FlyoutMenu.tsx
@@ -1,12 +1,11 @@
 import { FC, ReactNode, useState } from "react";
 import { RiCheckboxMultipleBlankLine } from "react-icons/ri";
-import { List, ListOfSections, ListOfTasks, Section } from "../models";
+import { List, Section } from "../models";
 import { MdAdd, MdMenu, MdRedo, MdShare, MdUndo } from "react-icons/md";
 import "./FlyoutMenu.css";
-import { Account, Group } from "jazz-tools";
 import { useJazzGroups } from "./hooks/useJazzGroups";
 import { useAccount } from "..";
-import { canEditValue } from "../util/jazz";
+import { canEditValue, createEmptyList } from "../util/jazz";
 import { ShareDialog } from "./ShareDialog";
 
 export type FlyoutMenuProps = {
@@ -14,30 +13,6 @@ export type FlyoutMenuProps = {
   setList: (newList: List) => void;
 };
 
-const createEmptyList = (owner: Account | Group) => {
-  const defaultTaskList = ListOfTasks.create([], {
-    owner,
-  });
-  const defaultSection = Section.create(
-    {
-      title: "DEFAULT",
-      tasks: defaultTaskList,
-    },
-    { owner }
-  );
-  const defaultSectionList = ListOfSections.create([], {
-    owner,
-  });
-  const newList = List.create(
-    {
-      title: "New list",
-      defaultSection: defaultSection,
-      sections: defaultSectionList,
-    },
-    { owner }
-  );
-  return newList;
-};
 
 const noop = () => {};
 

--- a/src/ui/MainComponent.tsx
+++ b/src/ui/MainComponent.tsx
@@ -1,6 +1,8 @@
 import { FC } from "react";
 import { List } from "../models";
-import { canEditValue } from "../util/jazz";
+import { canEditValue, createEmptyList } from "../util/jazz";
+import { useAccount } from "..";
+import { useJazzGroups } from "./hooks/useJazzGroups";
 import { DragAndDropContext } from "./DragAndDropContext";
 import { SectionComponent, SectionAdder } from "./SectionComponent";
 import { DraggableList } from "./DraggableList";
@@ -9,9 +11,16 @@ import "./MainComponent.css";
 type MainComponentProps = {
   list: List | undefined;
   loading: boolean;
+  setList: (newList: List) => void;
 };
 
-export const MainComponent: FC<MainComponentProps> = ({ list, loading }) => {
+export const MainComponent: FC<MainComponentProps> = ({
+  list,
+  loading,
+  setList,
+}) => {
+  const { me } = useAccount();
+  const { ownerGroup, loadingOwnerGroup } = useJazzGroups(me);
   if (loading) {
     return (
       <main>
@@ -19,9 +28,17 @@ export const MainComponent: FC<MainComponentProps> = ({ list, loading }) => {
       </main>
     );
   } else if (!list) {
+    const createList = () => {
+      if (ownerGroup) {
+        const newList = createEmptyList(ownerGroup);
+        setList(newList);
+      }
+    };
     return (
       <main>
-        <p>Use the menu to create a new list.</p>
+        <button onClick={createList} disabled={loadingOwnerGroup}>
+          Create a new list
+        </button>
       </main>
     );
   } else {

--- a/src/util/jazz.ts
+++ b/src/util/jazz.ts
@@ -18,3 +18,31 @@ export const insertIntoJazzList = <T>(
     list.splice(index, 0, item);
   }
 };
+
+import { Account, Group } from "jazz-tools";
+import { List, ListOfSections, ListOfTasks, Section } from "../models";
+
+export const createEmptyList = (owner: Account | Group) => {
+  const defaultTaskList = ListOfTasks.create([], {
+    owner,
+  });
+  const defaultSection = Section.create(
+    {
+      title: "DEFAULT",
+      tasks: defaultTaskList,
+    },
+    { owner }
+  );
+  const defaultSectionList = ListOfSections.create([], {
+    owner,
+  });
+  const newList = List.create(
+    {
+      title: "New list",
+      defaultSection: defaultSection,
+      sections: defaultSectionList,
+    },
+    { owner }
+  );
+  return newList;
+};


### PR DESCRIPTION
## Summary
- enable reuse of list creation logic via `createEmptyList`
- provide a button to create a list when no list is selected
- wire through `setList` prop from `App` to `MainComponent`
- update `FlyoutMenu` to use shared list creation function

## Testing
- `yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684be38d8fa08321a3e35de13a95a2f7