### PR TITLE
Fix share dialog bug

### DIFF
--- a/src/ui/ShareDialog.tsx
+++ b/src/ui/ShareDialog.tsx
@@ -77,7 +77,7 @@ const ShareButton = ({ url, listName }: { url: string; listName: string }) => {
     title: `Shared List: ${listName}`,
     url: url,
   };
-  if (!navigator.canShare(shareData)) {
+  if (!navigator.canShare || !navigator.canShare(shareData)) {
     alert("This browser does not support the share API");
     return null;
   }


### PR DESCRIPTION
## Summary
- check for `navigator.canShare` before calling it in the share dialog since some browsers may not support it

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_684be35ca1dc8321810746be4007e4fe